### PR TITLE
Remove compiler warning, fix examples

### DIFF
--- a/Cmd.cpp
+++ b/Cmd.cpp
@@ -148,6 +148,11 @@ void cmd_handler()
         msg_ptr = msg;
         break;
 
+    case '\n':
+        // ignore newline characters. they usually come in pairs
+        // with the \r characters we use for newline detection.
+        break;
+
     case '\b':
         // backspace
         stream->print(c);
@@ -221,6 +226,18 @@ void cmdAdd(const char *name, void (*func)(int argc, char **argv))
     cmd_tbl->func = func;
     cmd_tbl->next = cmd_tbl_list;
     cmd_tbl_list = cmd_tbl;
+}
+
+/**************************************************************************/
+/*!
+    Get a pointer to the stream used by the interpreter. This allows
+    commands to use the same communication channel as the interpreter
+    without tracking it in the main program.
+*/
+/**************************************************************************/
+Stream* cmdGetStream(void)
+{
+    return stream;
 }
 
 /**************************************************************************/

--- a/Cmd.cpp
+++ b/Cmd.cpp
@@ -202,7 +202,7 @@ void cmdInit(Stream *str)
     at the setup() portion of the sketch.
 */
 /**************************************************************************/
-void cmdAdd(char *name, void (*func)(int argc, char **argv))
+void cmdAdd(const char *name, void (*func)(int argc, char **argv))
 {
     // alloc memory for command struct
     cmd_tbl = (cmd_t *)malloc(sizeof(cmd_t));

--- a/Cmd.h
+++ b/Cmd.h
@@ -55,6 +55,7 @@ typedef struct _cmd_t
 void cmdInit(Stream *);
 void cmdPoll();
 void cmdAdd(const char *name, void (*func)(int argc, char **argv));
+Stream* cmdGetStream(void);
 uint32_t cmdStr2Num(char *str, uint8_t base);
 
 #endif //CMD_H

--- a/Cmd.h
+++ b/Cmd.h
@@ -54,7 +54,7 @@ typedef struct _cmd_t
 
 void cmdInit(Stream *);
 void cmdPoll();
-void cmdAdd(char *name, void (*func)(int argc, char **argv));
+void cmdAdd(const char *name, void (*func)(int argc, char **argv));
 uint32_t cmdStr2Num(char *str, uint8_t base);
 
 #endif //CMD_H

--- a/examples/cmd_line_ex1_hello/cmd_line_ex1_hello.ino
+++ b/examples/cmd_line_ex1_hello/cmd_line_ex1_hello.ino
@@ -9,7 +9,8 @@ to them.
 void setup()
 {
   // init the command line and set it for a speed of 57600
-  cmdInit(57600);
+  Serial.begin(57600);
+  cmdInit(&Serial);
   
   // add the commands to the command table. These functions must
   // already exist in the sketch. See the functions below. 
@@ -34,5 +35,6 @@ void loop()
 // That's it. 
 void hello(int arg_cnt, char **args)
 {
-  Serial.println("Hello world.");
+  cmdGetStream()->println("Hello world.");
 }
+

--- a/examples/cmd_line_ex2_args/cmd_line_ex2_args.ino
+++ b/examples/cmd_line_ex2_args/cmd_line_ex2_args.ino
@@ -9,7 +9,8 @@ to them.
 void setup()
 {
   // init the command line and set it for a speed of 57600
-  cmdInit(57600);
+  Serial.begin(57600);
+  cmdInit(&Serial);
   
   // add the commands to the command table. These functions must
   // already exist in the sketch. See the functions below. 
@@ -49,11 +50,13 @@ void loop()
 // Arg 9: yay
 void arg_display(int arg_cnt, char **args)
 {
+  Stream *s = cmdGetStream();
+  
   for (int i=0; i<arg_cnt; i++)
   {
-    Serial.print("Arg ");
-    Serial.print(i);
-    Serial.print(": ");
-    Serial.println(args[i]);
+    s->print("Arg ");
+    s->print(i);
+    s->print(": ");
+    s->println(args[i]);
   }
 }

--- a/examples/cmd_line_ex3_led_blink/cmd_line_ex3_led_blink.ino
+++ b/examples/cmd_line_ex3_led_blink/cmd_line_ex3_led_blink.ino
@@ -16,7 +16,8 @@ void setup()
   pinMode(led_pin, OUTPUT); 
   
   // init the command line and set it for a speed of 57600
-  cmdInit(57600);
+  Serial.begin(57600);
+  cmdInit(&Serial);
   
   // add the commands to the command table. These functions must
   // already exist in the sketch. See the functions below. 

--- a/examples/cmd_line_ex4_pwm/cmd_line_ex4_pwm.ino
+++ b/examples/cmd_line_ex4_pwm/cmd_line_ex4_pwm.ino
@@ -10,11 +10,12 @@ int pwm_pin = 10;
 
 void setup()
 {
-  // set the led pin as an output. its part of the demo.
+  // set the PWM pin as an output. its part of the demo.
   pinMode(pwm_pin, OUTPUT); 
   
   // init the command line and set it for a speed of 57600
-  cmdInit(57600);
+  Serial.begin(57600);
+  cmdInit(&Serial);
   
   // add the commands to the command table. These functions must
   // already exist in the sketch. See the functions below. 

--- a/examples/cmd_line_ex5_multi_functions/cmd_line_ex5_multi_functions.ino
+++ b/examples/cmd_line_ex5_multi_functions/cmd_line_ex5_multi_functions.ino
@@ -18,7 +18,8 @@ void setup()
   pinMode(pwm_pin, OUTPUT); 
   
   // init the command line and set it for a speed of 57600
-  cmdInit(57600);
+  Serial.begin(57600);
+  cmdInit(&Serial);
   
   // add the commands to the command table. These functions must
   // already exist in the sketch. See the functions below. 
@@ -54,7 +55,7 @@ void loop()
 // hello
 void hello(int arg_cnt, char **args)
 {
-  Serial.println("Hello world.");
+  cmdGetStream()->println("Hello world.");
 }
 
 // Display the contents of the args string array. 
@@ -73,12 +74,13 @@ void hello(int arg_cnt, char **args)
 // Arg 6: baby
 void arg_display(int arg_cnt, char **args)
 {
+  Stream *s = cmdGetStream();
   for (int i=0; i<arg_cnt; i++)
   {
-    Serial.print("Arg ");
-    Serial.print(i);
-    Serial.print(": ");
-    Serial.println(args[i]);
+    s->print("Arg ");
+    s->print(i);
+    s->print(": ");
+    s->println(args[i]);
   }
 }
 


### PR DESCRIPTION
New versions of the Arduino IDE throw a compiler warning
if you pass a const char * aka string literal ("hello world") to
a char * function argument. This commit changes the prototype to
take a const char *.