### PR TITLE
Fixed compilation issue for Arm-based systems (at least Arduino NANO 33 IOT)

### DIFF
--- a/Cmd.cpp
+++ b/Cmd.cpp
@@ -138,7 +138,6 @@ void cmd_handler()
 
     switch (c)
     {
-    case '.':
     case '\r':
         // terminate the msg and reset the msg ptr. then send
         // it to the handler for processing.

--- a/Cmd.h
+++ b/Cmd.h
@@ -43,6 +43,7 @@
 
 #define MAX_MSG_SIZE    60
 #include <stdint.h>
+#include <Arduino.h>
 
 // command line structure
 typedef struct _cmd_t


### PR DESCRIPTION
I had to add this library for the submodule to compile (in Arduino IDE 1.8.13 (latest at the time))